### PR TITLE
Add SHA-256 hash generator web page

### DIFF
--- a/sha256-web/README.md
+++ b/sha256-web/README.md
@@ -1,0 +1,15 @@
+# SHA-256 Hash Generator Web App
+
+This folder contains a small single page application that lets you compute the
+SHA-256 hash of any text. It can be served via GitHub Pages.
+
+## Usage
+
+1. Navigate to the `sha256-web` directory in your browser once the repository is
+   hosted on GitHub Pages: `https://<username>.github.io/RandomProofs/sha256-web/`
+2. Enter any text in the input box and press **Hash It**.
+3. The resulting hash will appear below the form. Each result is kept so you can
+   review multiple inputs.
+
+The app uses the browser's `crypto.subtle.digest` API and does not require any
+server-side code.

--- a/sha256-web/index.html
+++ b/sha256-web/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SHA-256 Hash Generator</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background: #f5f5f5;
+        }
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            text-align: center;
+        }
+        form {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        input[type="text"] {
+            font-size: 1.2rem;
+            padding: 0.5rem 1rem;
+            width: 300px;
+            margin-bottom: 1rem;
+        }
+        button {
+            font-size: 1.2rem;
+            padding: 0.5rem 1rem;
+            cursor: pointer;
+        }
+        .results {
+            margin-top: 2rem;
+            width: 80%;
+            max-width: 600px;
+        }
+        .result-item {
+            background: #fff;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            word-break: break-all;
+        }
+        .input-text {
+            font-weight: bold;
+        }
+        .hash-text {
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+    <h1>SHA-256 Hash Generator</h1>
+    <form id="hashForm">
+        <input type="text" id="inputValue" placeholder="Enter text" required />
+        <button type="submit">Hash It</button>
+    </form>
+    <div class="results" id="results"></div>
+    <script>
+        async function sha256(message) {
+            const msgBuffer = new TextEncoder().encode(message);
+            const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+            const hashArray = Array.from(new Uint8Array(hashBuffer));
+            const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+            return hashHex;
+        }
+
+        document.getElementById('hashForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const input = document.getElementById('inputValue');
+            const text = input.value;
+            const hash = await sha256(text);
+            const results = document.getElementById('results');
+            const div = document.createElement('div');
+            div.className = 'result-item';
+            div.innerHTML = `<div class="input-text">Input: ${text}</div><div class="hash-text">SHA-256: ${hash}</div>`;
+            results.prepend(div);
+            input.value = '';
+            input.focus();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple SHA‑256 single page app under `sha256-web`

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_6882a5b617d0832889dbb59754abfdde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a web application for generating SHA-256 hashes from user input, displaying both the original text and its hash for multiple entries.
  
* **Documentation**
  * Added detailed instructions and usage guidelines for the SHA-256 hash generator web app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->